### PR TITLE
hfp-3474 remove default alt text

### DIFF
--- a/image.js
+++ b/image.js
@@ -21,7 +21,7 @@ var H5P = H5P || {};
       this.height = params.file.height;
     }
 
-    this.alt = params.alt !== undefined ? params.alt : 'New image';
+    this.alt = params.alt !== undefined ? params.alt : '';
 
     if (params.title !== undefined) {
       this.title = params.title;


### PR DESCRIPTION
This fixes decorative images being skipped by assistive technologies,
instead of being announced as "New image"
