### PR TITLE
Fix alt and title attribute

### DIFF
--- a/image.css
+++ b/image.css
@@ -7,3 +7,9 @@
   background: url('placeholder.svg');
   background-size: cover;
 }
+.h5p-image .h5p-image-tooltip {
+  bottom: 0;
+  left: auto;
+  right: 0;
+  transform: none;
+}

--- a/image.js
+++ b/image.js
@@ -26,7 +26,7 @@ var H5P = H5P || {};
       '';
 
     if (params.title !== undefined) {
-      this.title = params.title;
+      this.title = this.stripHTML(this.htmlDecode(params.title));
     }
   };
 
@@ -49,7 +49,6 @@ var H5P = H5P || {};
           width: '100%',
           height: '100%',
           class: 'h5p-placeholder',
-          title: this.title === undefined ? '' : this.title,
           on: {
             load: function () {
               self.trigger('loaded');
@@ -62,7 +61,6 @@ var H5P = H5P || {};
           height: '100%',
           src: source,
           alt: this.alt,
-          title: this.title === undefined ? '' : this.title,
           on: {
             load: function () {
               self.trigger('loaded');
@@ -73,6 +71,14 @@ var H5P = H5P || {};
     }
 
     $wrapper.addClass('h5p-image').html(self.$img);
+
+    // Use custom tooltip instead of title attribute (causes a11y issues)
+    if (this.title) {
+      H5P.Tooltip($wrapper.get(0), {
+        text: this.title,
+        classes: ['h5p-image-tooltip']
+      });
+    }
   };
 
   /**

--- a/image.js
+++ b/image.js
@@ -21,7 +21,9 @@ var H5P = H5P || {};
       this.height = params.file.height;
     }
 
-    this.alt = (!params.decorative && params.alt !== undefined) ? params.alt : '';
+    this.alt = (!params.decorative && params.alt !== undefined) ?
+      this.stripHTML(this.htmlDecode(params.alt)) :
+      '';
 
     if (params.title !== undefined) {
       this.title = params.title;
@@ -71,6 +73,29 @@ var H5P = H5P || {};
     }
 
     $wrapper.addClass('h5p-image').html(self.$img);
+  };
+
+  /**
+   * Retrieve decoded HTML encoded string.
+   *
+   * @param {string} input HTML encoded string.
+   * @returns {string} Decoded string.
+   */
+  H5P.Image.prototype.htmlDecode = function (input) {
+    const dparser = new DOMParser().parseFromString(input, 'text/html');
+    return dparser.documentElement.textContent;
+  };
+
+  /**
+   * Retrieve string without HTML tags.
+   *
+   * @param {string} input Input string.
+   * @returns {string} Output string.
+   */
+  H5P.Image.prototype.stripHTML = function (html) {
+    const div = document.createElement('div');
+    div.innerHTML = html;
+    return div.textContent || div.innerText || '';
   };
 
   return H5P.Image;


### PR DESCRIPTION
When merged in, will
- fix HTML encoding for `alt` tag and
- replace `title` attribute with custom H5P core tooltip.

Replaces https://github.com/h5p/h5p-image/pull/38