### PR TITLE
HFP-3641 Allow alt tags with up to 1024 characters

### DIFF
--- a/semantics.json
+++ b/semantics.json
@@ -19,6 +19,7 @@
     "label": "Alternative text",
     "importance": "high",
     "description": "Required. If the browser can't load the image this text will be displayed instead. Also used by \"text-to-speech\" readers.",
+    "maxLength": 1024,
     "widget": "showWhen",
     "showWhen": {
       "rules": [


### PR DESCRIPTION
The `alt` tags are meant to improve the accessibility, and an alternative description helping visually impaired people can easily exceed the default character length of 255 for a text field.

When merged in, the maximum character length for the `alt` tag will be set to 1024.