### PR TITLE
Add support for WCAG 2.1 SC 2.2.2: Handling of animated GIFs

### DIFF
--- a/image.css
+++ b/image.css
@@ -13,3 +13,30 @@
   right: 0;
   transform: none;
 }
+.h5p-image .h5p-image-button-play {
+  background-color: rgb(23,104,196);
+  border: none;
+  box-sizing: border-box;
+  color: #fff;
+  font-family: 'H5PFontAwesome4';
+  height: 3em;
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  right: 0.5em;
+  top: 0.5em;
+  width: 3em;
+}
+.h5p-image .h5p-image-button-play:hover {
+  background-color: rgba(23,104,196,0.9);
+  cursor: pointer;
+}
+.h5p-image .h5p-image-button-play:active {
+  background-color: rgba(23,104,196,0.95);
+}
+.h5p-image .h5p-image-button-play::before {
+  content: "\f04b";
+}
+.h5p-image .h5p-image-button-play.pause::before {
+  content: "\f04c";
+}

--- a/image.js
+++ b/image.js
@@ -11,6 +11,9 @@ var H5P = H5P || {};
   H5P.Image = function (params, id, extras) {
     H5P.EventDispatcher.call(this);
     this.extras = extras;
+    this.params = params;
+    this.params.startImageAnimation = 'Start image animation';
+    this.params.stopImageAnimation = 'Stop image animation';
 
     if (params.file === undefined || !(params.file instanceof Object)) {
       this.placeholder = true;
@@ -19,6 +22,7 @@ var H5P = H5P || {};
       this.source = H5P.getPath(params.file.path, id);
       this.width = params.file.width;
       this.height = params.file.height;
+      this.mime = params.file.mime || '';
     }
 
     this.alt = (!params.decorative && params.alt !== undefined) ?
@@ -42,6 +46,7 @@ var H5P = H5P || {};
   H5P.Image.prototype.attach = function ($wrapper) {
     var self = this;
     var source = this.source;
+    self.$wrapper = $wrapper;
 
     if (self.$img === undefined) {
       if(self.placeholder) {
@@ -73,7 +78,202 @@ var H5P = H5P || {};
     }
 
     $wrapper.addClass('h5p-image').html(self.$img);
+
+    /*
+     * Only handling if image is gif and user requests reduced motion.
+     * @see https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
+     */
+    if (
+      this.mime === 'image/gif' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)')?.matches
+    ) {
+      self.on('loaded', function () {
+        const image = self.$img.get(0);
+
+        // Promise resolving with true if src is animated gif
+        self.isGIFAnimated(image.src).then(function (isAnimated) {
+          if (!isAnimated) {
+            return; // GIF is not animated
+          }
+
+          self.staticImage = self.buildStaticReplacement(image);
+
+          // Add button to toggle gif animation on/off
+          self.playButton = document.createElement('button');
+          self.playButton.classList.add('h5p-image-button-play');
+          self.playButton.setAttribute('type', 'button');
+          self.playButton.addEventListener('click', function () {
+            self.swapImage();
+          });
+          $wrapper.get(0).append(self.playButton);
+
+          self.showsStaticImage = true;
+          self.swapImage();
+        }, function () {
+          return; // Error
+        });
+      });
+    }
   };
+
+  /**
+   * Swap image. Used to switch between animated image and static image.
+   */
+  H5P.Image.prototype.swapImage = function() {
+    this.showsStaticImage = !this.showsStaticImage;
+
+    this.playButton.classList.toggle('pause', this.showsStaticImage);
+    if (this.showsStaticImage) {
+      this.$wrapper.get(0).replaceChild(this.$img.get(0), this.staticImage);
+      this.playButton.setAttribute(
+        'aria-label', this.params.stopImageAnimation
+      );
+    }
+    else {
+      this.$wrapper.get(0).replaceChild(this.staticImage, this.$img.get(0));
+      this.playButton.setAttribute(
+        'aria-label', this.params.startImageAnimation
+      );
+    }
+
+    this.trigger('resize');
+  };
+
+  /**
+   * Build static replacement of image.
+   *
+   * @param {HTMLImageElement} image Image to get static replacement for.
+   * @returns {HTMLImageElement|HTMLCanvasElement} Static replacement.
+   */
+  H5P.Image.prototype.buildStaticReplacement = function (image) {
+    if (!image) {
+      return;
+    }
+
+    // Image size is likely float, but canvas size cannot.
+    const style = window.getComputedStyle(image);
+    const imageSize = {
+      height: Math.round(parseFloat(style.getPropertyValue('height'))),
+      width: Math.round(parseFloat(style.getPropertyValue('width')))
+    }
+
+    // Copy image to canvas
+    const canvas = document.createElement('canvas');
+    canvas.width = imageSize.width;
+    canvas.height = imageSize.height;
+    canvas
+      .getContext('2d')
+      .drawImage(image, 0, 0, imageSize.width, imageSize.height);
+
+    // Try to retrieve encoded image URL
+    let newSrc;
+    let replacement;
+    try {
+      newSrc = canvas.toDataURL('image/gif');
+      replacement = document.createElement('img');
+    }
+    catch (error) {
+      // Fallback. e.g. cross-origin issues
+      replacement = canvas;
+    }
+
+    /*
+     * toDataURL requires images on iOS to have a maximum size of 3 megapixels
+     * for devices with less than 256 MB RAM and 5 megapixels for devices with
+     * greater or equal than 256 MB RAM.
+     * https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/CreatingContentforSafarioniPhone/CreatingContentforSafarioniPhone.html#//apple_ref/doc/uid/TP40006482-SW15
+     */
+    if (newSrc.length < 7) {
+      replacement = canvas;
+    }
+
+    // Copy attributes of old source
+    for (let i = 0; i < image.attributes.length; i++) {
+      const attribute = image.attributes[i];
+      replacement.setAttribute(attribute.name, attribute.value);
+    }
+
+    if (newSrc) {
+      replacement.src = newSrc;
+    }
+    else {
+      // Common practice to make canvas behave like image to screen readers
+      replacement.setAttribute('role', 'img');
+      if (image.getAttribute('alt')) {
+        replacement.setAttribute('aria-label', image.getAttribute('alt'));
+      }
+    }
+
+    return replacement;
+  };
+
+  /**
+   * Determine whether a GIF file is animated.
+   *
+   * @param {string} url URL of GIF to be checked.
+   * @returns {Promise} Promise resolving with boolean, rejecting with xhr object extract.
+   */
+  H5P.Image.prototype.isGIFAnimated = function (url) {
+    return new Promise(function (resolve, reject) {
+      const xhr = new XMLHttpRequest();
+      xhr.open('GET', url, true);
+      xhr.responseType = 'arraybuffer';
+
+      // Reject Promise if file could not be loaded
+      xhr.onreadystatechange = function () {
+        if (xhr.readyState === 4 && xhr.status !== 200) {
+          reject({ status: xhr.status, statusText: xhr.statusText });
+        }
+      }
+
+      /*
+       * Determine GIF delay time as indicator for animation
+       * @see https://gist.github.com/zakirt/faa4a58cec5a7505b10e3686a226f285
+       */
+      xhr.onload = function() {
+        const buffer = xhr.response;
+
+        // Offset bytes for the header section
+        const HEADER_LEN = 6;
+
+        // Offset bytes for logical screen description section
+        const LOGICAL_SCREEN_DESC_LEN = 7;
+
+        // Start from last 4 bytes of Logical Screen Descriptor
+        const dv = new DataView(buffer, HEADER_LEN + LOGICAL_SCREEN_DESC_LEN - 3);
+        const globalColorTable = dv.getUint8(0); // aka packet byte
+        let globalColorTableSize = 0;
+        let offset = 0;
+
+        // Check first bit, if 0, then we don't have Global Color Table
+        if (globalColorTable & 0x80) {
+          /*
+           * Grab last 3 bits to compute global color table
+           * size -> RGB * 2^(N+1). N is value in last 3 bits.
+           */
+          globalColorTableSize = 3 * Math.pow(2, (globalColorTable & 0x7) + 1);
+        }
+
+        // Move on to Graphics Control Extension
+        offset = 3 + globalColorTableSize;
+
+        const extensionIntroducer = dv.getUint8(offset);
+        const graphicsConrolLabel = dv.getUint8(offset + 1);
+        let delayTime = 0;
+
+        // Graphics Control Extension section is where GIF animation data is
+        // First 2 bytes must be 0x21 and 0xF9
+        if (extensionIntroducer & 0x21 && graphicsConrolLabel & 0xf9) {
+          // Skip to 2 bytes with delay time
+          delayTime = dv.getUint16(offset + 4);
+        }
+
+        resolve(Boolean(delayTime));
+      };
+
+      xhr.send();
+    });
+  }
 
   /**
    * Retrieve decoded HTML encoded string.

--- a/image.js
+++ b/image.js
@@ -80,11 +80,13 @@ var H5P = H5P || {};
     $wrapper.addClass('h5p-image').html(self.$img);
 
     /*
-     * Only handling if image is gif and user requests reduced motion.
+     * Only handle if image is gif, animation is essential and user requested
+     * reduced motion
      * @see https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
      */
     if (
       this.mime === 'image/gif' &&
+      !this.params.isAnimationEssential &&
       window.matchMedia('(prefers-reduced-motion: reduce)')?.matches
     ) {
       self.on('loaded', function () {

--- a/language/.en.json
+++ b/language/.en.json
@@ -18,6 +18,14 @@
     {
       "label": "Image content name",
       "default": "Image"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/.en.json
+++ b/language/.en.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternative text",
       "description": "Required. If the browser can't load the image this text will be displayed instead. Also used by \"text-to-speech\" readers."
     },

--- a/language/af.json
+++ b/language/af.json
@@ -18,6 +18,14 @@
     {
       "label": "Prent inhoud naam",
       "default": "Prent"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/af.json
+++ b/language/af.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternatiewe teks",
       "description": "Vereis. Indien die webleser nie die prent kan laai nie, sal die teks vertoon word. Word ook gebruik vir \"teks-na-spraak\" lesers."
     },

--- a/language/ar.json
+++ b/language/ar.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "النص البديل",
       "description": "مطلوبة. إذا كان المتصفح لم يتمكن من تحميل الصورة سيتم عرض هذا النص بدلا من ذلك. تستخدم أيضا من قبل مكبرات الصوت للقراءة"
     },

--- a/language/ar.json
+++ b/language/ar.json
@@ -18,6 +18,14 @@
     {
       "label": "اسم ملف الصورة",
       "default": "الصورة"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/bg.json
+++ b/language/bg.json
@@ -18,6 +18,14 @@
     {
       "label": "Име на тип съдържание Изображение",
       "default": "Изображение"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/bg.json
+++ b/language/bg.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Алтернативен текст",
       "description": "Задължителен. Ако браузърът не може да зареди изображението, вместо него ще се покаже този текст. Използва се също и от екранните четци \"text-to-speech\"."
     },

--- a/language/bs.json
+++ b/language/bs.json
@@ -18,6 +18,14 @@
     {
       "label": "Naziv slike",
       "default": "Image"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/bs.json
+++ b/language/bs.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternativni tekst",
       "description": "Obavezno. U slučaju da se slika ne pokaže onda će se pokazati ovaj tekst ili biti elektronskm glasom pročitan."
     },

--- a/language/ca.json
+++ b/language/ca.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Text alternatiu",
       "description": "Requerit. Si el navegador no pot carregar la imatge es mostrarà aquest text. També s’utilitza per a lectors de \"text a veu\"."
     },

--- a/language/ca.json
+++ b/language/ca.json
@@ -18,6 +18,14 @@
     {
       "label": "Nom del contingut de la imatge",
       "default": "Imatge"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/cs.json
+++ b/language/cs.json
@@ -18,6 +18,14 @@
     {
       "label": "Název obsahu obrázku",
       "default": "Obrázek"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/cs.json
+++ b/language/cs.json
@@ -8,6 +8,10 @@
       "description": "Tuto možnost zvolte, pokud má být obrázek čistě dekoračního charakteru a nedodává obsahu stránky nové informace. Obrázek bude odečítači obrazovky ignorován a nebude doplněn alternativním textem."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternativní text",
       "description": "Povinné. Pokud prohlížeč nemůže načíst obrázek, zobrazí se místo toho tento text. Také se používá \"text-to-speech\" čtečka."
     },

--- a/language/cy.json
+++ b/language/cy.json
@@ -18,6 +18,14 @@
     {
       "label": "Enw cynnwys y ddelwedd",
       "default": "Delwedd"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/cy.json
+++ b/language/cy.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Testun amgen",
       "description": "Angenrheidiol. Os dyw'r porwr yn methu llwytho'r ddelwedd, caiff y testun hwn ei ddangos yn ei lle. Caiff ei ddefnyddio gan ddarllenwyr \"llefaru testun\" hefyd."
     },

--- a/language/da.json
+++ b/language/da.json
@@ -18,6 +18,14 @@
     {
       "label": "Image content name",
       "default": "Image"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/da.json
+++ b/language/da.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternative text",
       "description": "Required. If the browser can't load the image this text will be displayed instead. Also used by \"text-to-speech\" readers."
     },

--- a/language/de.json
+++ b/language/de.json
@@ -8,6 +8,10 @@
       "description": "Wähle diese Option, wenn das Bild rein dekorativ ist und keine Informationen zum Inhalt der Seite hinzufügt. Es wird von Vorlesewerkzeugen ignoriert und erhält keinen Alternativtext."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternativtext",
       "description": "Erforderlich. Falls das Bild nicht geladen werden kann, wird dieser Text stattdessen angezeigt. Wird auch zum Vorlesen von Bildschirmtexten genutzt."
     },

--- a/language/de.json
+++ b/language/de.json
@@ -18,6 +18,14 @@
     {
       "label": "Name des Bildinhalts",
       "default": "Bild"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/el.json
+++ b/language/el.json
@@ -18,6 +18,14 @@
     {
       "label": "Όνομα περιεχομένου εικόνας",
       "default": "Εικόνα"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/el.json
+++ b/language/el.json
@@ -8,6 +8,10 @@
       "description": "Ενεργοποιήστε αυτήν την επιλογή εάν η εικόνα είναι καθαρά διακοσμητική και δεν προσθέτει πληροφορίες στο περιεχόμενο της σελίδας. Θα αγνοηθεί από τους αναγνώστες οθόνης και δεν θα δοθεί εναλλακτικό κείμενο."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Εναλλακτικό κείμενο",
       "description": "Αυτό το κείμενο εμφανίζεται σε περίπτωση που ο φυλλομετρητής αδυνατεί να φορτώσει την εικόνα. Χρησιμοποιείται επίσης και κατά την ακουστική υποβοήθηση. (απαιτείται)"
     },

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -18,6 +18,14 @@
     {
       "label": "Nombre del contenido de la imagen",
       "default": "Imagen"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -8,6 +8,10 @@
       "description": "Habilite esta opción si la imagen es puramente decorativa y no añade información al contenido de la página. Será ignorada por lectores de pantalla en voz alta y no se le dará ningún texto alternativo."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Texto alternativo",
       "description": "Necesario. Si el navegador no puede cargar la imagen este texto será mostrado en su lugar. También es usado por lectores de \"texto-hablado\"."
     },

--- a/language/es.json
+++ b/language/es.json
@@ -18,6 +18,14 @@
     {
       "label": "Nombre del contenido de la imagen",
       "default": "Imagen"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/es.json
+++ b/language/es.json
@@ -8,6 +8,10 @@
       "description": "Habilita esta opción si la imagen es puramente decorativa y no añade información al contenido de la página. Será ignorada por los lectores de pantalla y no se le dará ningún texto alternativo."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Texto alternativo",
       "description": "Necesario. Si el navegador no puede cargar la imagen, se mostrará este texto en su lugar. Usado también por lectores de pantalla."
     },

--- a/language/et.json
+++ b/language/et.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternatiivtekst",
       "description": "Nõutud. Kui brauser ei saa pilti laadida, siis näidatakse seda teksti. Samuti kasutatakse \"text-to-speech\" lugejais."
     },

--- a/language/et.json
+++ b/language/et.json
@@ -18,6 +18,14 @@
     {
       "label": "Pildisisu nimi",
       "default": "Pilt"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/eu.json
+++ b/language/eu.json
@@ -18,6 +18,14 @@
     {
       "label": "Irudiaren edukiaren izena",
       "default": "Irudia"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/eu.json
+++ b/language/eu.json
@@ -8,6 +8,10 @@
       "description": "Aukera hau gaitu ezazu irudia apaingarria baino ez bada eta ez badio orriko edukiari informaziorik gehitzen. Pantaila irakurgailuek ez dute kontuan izango eta ez diote ordezko testurik emango."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Ordezko testua",
       "description": "Beharrezkoa da. Nabigatzaileak ezin badu irudia kargatu, bere ordez testu hau bistaratuko da. Testu-irakurleek ere erabilia."
     },

--- a/language/fa.json
+++ b/language/fa.json
@@ -18,6 +18,14 @@
     {
       "label": "نام محتوای تصویر",
       "default": "تصویر"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/fa.json
+++ b/language/fa.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "متن جایگزین",
       "description": "الزامی. اگر مروگر نتواند تصویر را بارگیری کند، این متن به جای آن نمایش داده خواهد شد. همچنین مبدل متن به گفتار از آن استفاده خواهد کرد."
     },

--- a/language/fi.json
+++ b/language/fi.json
@@ -18,6 +18,14 @@
     {
       "label": "Sisältötyypin nimi",
       "default": "Kuva"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/fi.json
+++ b/language/fi.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Vaihtoehtoinen kuvaus",
       "description": "Vaaditaan. Näytetään, jos selain ei saa ladattua kuvaa. Kuvausta käyttävät myös ruudunlukijasovellukset."
     },

--- a/language/fr.json
+++ b/language/fr.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Texte alternatif",
       "description": "Obligatoire. Ce texte sera affiché si l'image n'apparaît pas dans le navigateur."
     },

--- a/language/fr.json
+++ b/language/fr.json
@@ -18,6 +18,14 @@
     {
       "label": "Légende",
       "default": "Image"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/gl.json
+++ b/language/gl.json
@@ -8,6 +8,10 @@
       "description": "Activa esta opción se a imaxe e puramente decorativa e non engade ningunha información ao contido da páxina. Será ignorada polos lectores de pantalla e non terá texto alternativo."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Texto alternativo",
       "description": "Requirido. Se o navegador non pode cargar a imaxe, amosarase este texto no seu lugar. Úsase tamén para os lectores de pantalla."
     },

--- a/language/gl.json
+++ b/language/gl.json
@@ -18,6 +18,14 @@
     {
       "label": "Nome do contido da imaxe",
       "default": "Imaxe"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/he.json
+++ b/language/he.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "טקסט חלופי",
       "description": "נחוץ. אם הדפדפן לא יכול להעלות את התמונה טקסט זה יוצג במקום. בשימוש גם על ידי קוראי \"מטקסט לדיבור\"."
     },

--- a/language/he.json
+++ b/language/he.json
@@ -18,6 +18,14 @@
     {
       "label": "שם תוכן תמונה",
       "default": "תמונה"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/hu.json
+++ b/language/hu.json
@@ -18,6 +18,14 @@
     {
       "label": "Image content name",
       "default": "Image"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/hu.json
+++ b/language/hu.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternative text",
       "description": "Required. If the browser can't load the image this text will be displayed instead. Also used by \"text-to-speech\" readers."
     },

--- a/language/it.json
+++ b/language/it.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Testo alternativo",
       "description": "Richiesto. Se il browser non è in grado di caricare l'immagine sarà visualizzato questo testo. Usato anche per il lettore vocale."
     },

--- a/language/it.json
+++ b/language/it.json
@@ -18,6 +18,14 @@
     {
       "label": "Nome del contenuto dell'immagine",
       "default": "Immagine"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/ja.json
+++ b/language/ja.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "代替テキスト",
       "description": "必須。ブラウザーが画像をロードできない場合は、このテキストが代わりに表示されます。また、  リードスピーカーによって使用されます。"
     },

--- a/language/ja.json
+++ b/language/ja.json
@@ -18,6 +18,14 @@
     {
       "label": "画像のコンテンツ名",
       "default": "画像"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/ka.json
+++ b/language/ka.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "ალტერნატიული ტექსტი",
       "description": "აუცილებელი. თუ ბრაუზერი გამოსახულებას არ ჩატვირთავს, ეს ტექსტი მის ნაცვლად გამოჩნდება. ასევე გამოიყენება \"ტექსტის გამხმოვანებლის მიერ\"."
     },

--- a/language/ka.json
+++ b/language/ka.json
@@ -18,6 +18,14 @@
     {
       "label": "გამოსახულების შიგთავსის დასახელება",
       "default": "გამოსახულება"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/km.json
+++ b/language/km.json
@@ -18,6 +18,14 @@
     {
       "label": "ឈ្មោះសម្រាប់មាតិកា «រូបភាព»",
       "default": "រូបភាព"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/km.json
+++ b/language/km.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "ពាក្យជំនួស",
       "description": "ទាមទារ។ ប្រសិនបើកម្មវិធីបើកវិបសាយរបស់អ្នកមិនអាចដំណើរការរូបភាពនេះបាន វានឹងបង្ហាញពាក្យជំនួសនេះ។ ពាក្យនេះក៏ត្រូវបានប្រើក្នុងកម្មវិធីអានអត្ថបទជាសម្លេងផងដែរ។"
     },

--- a/language/ko.json
+++ b/language/ko.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "대안 텍스트",
       "description": "필수. 브라우저에서 이미지를 로드할 수 없는 경우 이 텍스트가 대신 표시된다. 또한 \"text-to-speech\"  자동 문장 말하기 기능(text-to-speech)에 의해 사용됩니다."
     },

--- a/language/ko.json
+++ b/language/ko.json
@@ -18,6 +18,14 @@
     {
       "label": "이미지 콘텐츠 이름",
       "default": "이미지"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/lt.json
+++ b/language/lt.json
@@ -18,6 +18,14 @@
     {
       "label": "Paveikslėlio turinio pavadinimas",
       "default": "Paveikslėlis"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/lt.json
+++ b/language/lt.json
@@ -8,6 +8,10 @@
       "description": "Įjunkite šią parinktį, jei vaizdas yra tik dekoratyvus ir neprideda jokios informacijos prie puslapio turinio. Ekrano skaitytuvai jo nepaisys ir nepateiks jokio alternatyvaus teksto."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternatyvus tekstas",
       "description": "Būtina. Jei naršyklė negali įkelti vaizdo, vietoj jo bus rodomas šis tekstas. Taip pat naudoja \"teksto į kalbą\" skaitytuvai."
     },

--- a/language/lv.json
+++ b/language/lv.json
@@ -18,6 +18,14 @@
     {
       "label": "Attēla satura nosaukums",
       "default": "Attēls"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/lv.json
+++ b/language/lv.json
@@ -8,6 +8,10 @@
       "description": "Iespējojiet šo opciju, ja attēls ir tikai dekoratīvs un lapas saturam nepievieno nekādu informāciju. Ekrāna lasītāji to ignorēs, un tam netiks piešķirts alternatīvs teksts."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternatīvais teksts",
       "description": "Obligāts. Ja pārlūkprogramma nevar ielādēt attēlu, tā vietā tiks atspoguļots šis teksts. To izmanto arī asistīvās tehnoloģijas."
     },

--- a/language/mn.json
+++ b/language/mn.json
@@ -18,6 +18,14 @@
     {
       "label": "Зургийн нэр",
       "default": "Зураг"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/mn.json
+++ b/language/mn.json
@@ -8,6 +8,10 @@
       "description": "Энэхүү сонголтыг сонгосноор зургыг засах боломжтой бөгөөд мэдээлэл нэмэх боломжгүй болно. Ямарваа нэгэн текстэн мэдээлэл нь харагдахгүй болно."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Нэмэлт текст",
       "description": "Шаардлагатай. Хэрэв броузер нь зургийг дэмжиж чадахгүй тохиолдолд текстэн мэдээлэл харагдана. Мөн текстээс яриа уруу хөврүүлэх болно."
     },

--- a/language/nb.json
+++ b/language/nb.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternativ tekst",
       "description": "Påkrevd. Hvis bildet ikke kan lastes vises denne teksten istedenfor. Denne blir også brukt ved talesyntese."
     },

--- a/language/nb.json
+++ b/language/nb.json
@@ -18,6 +18,14 @@
     {
       "label": "Innholdsnavn for bilde",
       "default": "Image"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/nl.json
+++ b/language/nl.json
@@ -18,6 +18,14 @@
     {
       "label": "Naam afbeeldingsinhoud",
       "default": "Afbeelding"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/nl.json
+++ b/language/nl.json
@@ -8,6 +8,10 @@
       "description": "Schakel deze optie in als de afbeelding puur decoratief is en geen informatie aan de inhoud van de pagina toevoegt. Schermlezers negeren de afbeelding dan en geven ook geen alternatieve tekst."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternatieve tekst",
       "description": "Vereist. Als de browser deze afbeelding niet kan laden wordt deze tekst getoond. Ook gebruikt door \"tekst-naar-spraak\" lezers."
     },

--- a/language/nn.json
+++ b/language/nn.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternativ tekst",
       "description": "Viss biletet ikkje kan lastast, blir denne teksten vist i istadenfor. Denne blir og nytta ved talesyntese."
     },

--- a/language/nn.json
+++ b/language/nn.json
@@ -18,6 +18,14 @@
     {
       "label": "Innhaldsnamn for bilete",
       "default": "Bilete"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/pl.json
+++ b/language/pl.json
@@ -18,6 +18,14 @@
     {
       "label": "Nazwa obrazu",
       "default": "Obraz"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/pl.json
+++ b/language/pl.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Tekst alternatywny",
       "description": "Wymagany. Ten tekst zostanie wyświetlony, jeśli przeglądarka nie zdoła załadować obrazu. Potrzebny także dla czytników ekranu."
     },

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -18,6 +18,14 @@
     {
       "label": "Nome do conteúdo de imagem",
       "default": "Imagem"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -8,6 +8,10 @@
       "description": "Ative esta opção se a imagem for puramente decorativa e não acrescentar nenhuma informação ao conteúdo da página. Ela será ignorada pelos leitores de tela e não receberá nenhum texto alternativo."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Texto alternativo",
       "description": "Obrigatório. Se o navegador não for capaz de exibir a imagem, este texto será exibido. Também utilizado por leitores de tela."
     },

--- a/language/pt.json
+++ b/language/pt.json
@@ -18,6 +18,14 @@
     {
       "label": "Nome do conteúdo da imagem",
       "default": "Imagem"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/pt.json
+++ b/language/pt.json
@@ -8,6 +8,10 @@
       "description": "Selecionar esta opção se a imagem for apenas decorativa e não acrescentar qualquer informação ao conteúdo da página. Será assim ignorada pelos leitores de ecrã, e não lhe será atribuído um texto alternativo.."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Texto alternativo",
       "description": "Obrigatório. Se o navegador não puder carregar a imagem, será mostrado este texto. Também é usado por leitores de \"texto para voz\"."
     },

--- a/language/ro.json
+++ b/language/ro.json
@@ -18,6 +18,14 @@
     {
       "label": "Image content name",
       "default": "Image"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/ro.json
+++ b/language/ro.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternative text",
       "description": "Required. If the browser can't load the image this text will be displayed instead. Also used by \"text-to-speech\" readers."
     },

--- a/language/ru.json
+++ b/language/ru.json
@@ -18,6 +18,14 @@
     {
       "label": "Название содержимого изображения",
       "default": "Изображение"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/ru.json
+++ b/language/ru.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Альтернативный текст",
       "description": "Обязательный. Если браузер не может загрузить изображение, этот текст будет отображаться вместо него. Также используется \"озвучкой текста\"."
     },

--- a/language/sl.json
+++ b/language/sl.json
@@ -8,6 +8,10 @@
       "description": "Oznaka opredeljuje sliko kot okrasno, ki ne dodaja vsebinskih informacij. Bralnik zaslona jo lahko zato prezre in ne posredujejo alternativnega besedila."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Nadomestno besedilo",
       "description": "Zahtevano. Besedilo se prikaže, če spletni brskalnik ne more naložiti slike. Besedilo uporabljajo tudi \"sintetizatorji govora\" (text-to-speech readers)."
     },

--- a/language/sl.json
+++ b/language/sl.json
@@ -18,6 +18,14 @@
     {
       "label": "Naslov vsebine slike",
       "default": "Slika"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/sma.json
+++ b/language/sma.json
@@ -18,6 +18,14 @@
     {
       "label": "Image content name",
       "default": "Image"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/sma.json
+++ b/language/sma.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternative text",
       "description": "Required. If the browser can't load the image this text will be displayed instead. Also used by \"text-to-speech\" readers."
     },

--- a/language/sme.json
+++ b/language/sme.json
@@ -18,6 +18,14 @@
     {
       "label": "Image content name",
       "default": "Image"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/sme.json
+++ b/language/sme.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternative text",
       "description": "Required. If the browser can't load the image this text will be displayed instead. Also used by \"text-to-speech\" readers."
     },

--- a/language/smj.json
+++ b/language/smj.json
@@ -18,6 +18,14 @@
     {
       "label": "Image content name",
       "default": "Image"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/smj.json
+++ b/language/smj.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternative text",
       "description": "Required. If the browser can't load the image this text will be displayed instead. Also used by \"text-to-speech\" readers."
     },

--- a/language/sr.json
+++ b/language/sr.json
@@ -18,6 +18,14 @@
     {
       "label": "Image content name",
       "default": "Image"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/sr.json
+++ b/language/sr.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternative text",
       "description": "Required. If the browser can't load the image this text will be displayed instead. Also used by \"text-to-speech\" readers."
     },

--- a/language/sv.json
+++ b/language/sv.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternativ text",
       "description": "Obligatorisk. Om bilden inte kan laddas i användarens webbläsare så kommer denna text visas istället. Används också av \"skärmläsare\"."
     },

--- a/language/sv.json
+++ b/language/sv.json
@@ -18,6 +18,14 @@
     {
       "label": "Namn på bildinnehåll",
       "default": "Bild"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/sw.json
+++ b/language/sw.json
@@ -18,6 +18,14 @@
     {
       "label": "Jina la maudhui ya picha",
       "default": "Picha"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/sw.json
+++ b/language/sw.json
@@ -8,6 +8,10 @@
       "description": "Washa chaguo hili ikiwa picha ni ya mapambo tu na haiongezi habari yoyote kwa maudhui kwenye ukurasa. Itapuuzwa na visoma skrini na haitapewa maandishi yoyote mbadala."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Maandishi mbadala",
       "description": "Inahitajika. Ikiwa kivinjari hakiwezi kupakia picha, maandishi haya yataonyeshwa badala yake. Inatumika pia na visomaji “maandishi-kwa-hotuba”."
     },

--- a/language/tr.json
+++ b/language/tr.json
@@ -18,6 +18,14 @@
     {
       "label": "Resim içerik adı",
       "default": "Resim"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/tr.json
+++ b/language/tr.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alt metin",
       "description": "Gerekli alan. Tarayıcı resmi yükleyemezse, bunun yerine bu metin görüntülenecektir. Ayrıca \"konuşma sentezleyiciler\" tarafından da kullanılır."
     },

--- a/language/uk.json
+++ b/language/uk.json
@@ -18,6 +18,14 @@
     {
       "label": "Назва вмісту зображення",
       "default": "Зображення"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/uk.json
+++ b/language/uk.json
@@ -8,6 +8,10 @@
       "description": "Виберіть цей параметр, якщо зображення є виключно декоративним і не додає жодної інформації до вмісту сторінки. Він ігнорується інструментами читання та не отримує альтернативний текст."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Альтернативний текст",
       "description": "Обов'язковий. Якщо браузер не може завантажити зображення, цей текст буде відображатись замість нього. Також використовується для \"озвучення тексту\"."
     },

--- a/language/vi.json
+++ b/language/vi.json
@@ -18,6 +18,14 @@
     {
       "label": "Image content name",
       "default": "Hình"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/vi.json
+++ b/language/vi.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "Alternative text",
       "description": "Required. If the browser can't load the image this text will be displayed instead. Also used by \"text-to-speech\" readers."
     },

--- a/language/zh-hans.json
+++ b/language/zh-hans.json
@@ -18,6 +18,14 @@
     {
       "label": "图像名称",
       "default": "图像"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/language/zh-hans.json
+++ b/language/zh-hans.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "替代文字",
       "description": "必填，当浏览器无法载入图片时会改显示此文字，同时这也作为视障者语音帮助。"
     },

--- a/language/zh-hant.json
+++ b/language/zh-hant.json
@@ -8,6 +8,10 @@
       "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
     },
     {
+      "label": "Animation is essential",
+      "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+    },
+    {
       "label": "替代文字",
       "description": "必填，當瀏覽器無法載入圖片時會改顯示此文字，同時這也作為視障者語音幫助。"
     },

--- a/language/zh-hant.json
+++ b/language/zh-hant.json
@@ -18,6 +18,14 @@
     {
       "label": "圖像名稱",
       "default": "Image"
+    },
+    {
+      "label": "Start image animation",
+      "default": "Start image animation"
+    },
+    {
+      "label": "Stop image animation",
+      "default": "Stop image animation"
     }
   ]
 }

--- a/library.json
+++ b/library.json
@@ -26,6 +26,13 @@
     "disable": 0,
     "disableExtraTitleField": 1
   },
+  "preloadedDependencies": [
+    {
+      "machineName": "FontAwesome",
+      "majorVersion": 4,
+      "minorVersion": 5
+    }
+  ],
   "editorDependencies": [
     {
       "machineName": "H5PEditor.ShowWhen",

--- a/semantics.json
+++ b/semantics.json
@@ -45,5 +45,21 @@
     "importance": "low",
     "common": true,
     "default": "Image"
+  },
+  {
+    "name": "startImageAnimation",
+    "type": "text",
+    "label": "Start image animation",
+    "importance": "low",
+    "common": true,
+    "default": "Start image animation"
+  },
+  {
+    "name": "stopImageAnimation",
+    "type": "text",
+    "label": "Stop image animation",
+    "importance": "low",
+    "common": true,
+    "default": "Stop image animation"
   }
 ]

--- a/semantics.json
+++ b/semantics.json
@@ -14,6 +14,13 @@
     "description": "Enable this option if the image is purely decorative and does not add any information to the content on the page. It will be ignored by screen readers and not given any alternative text."
   },
   {
+    "name": "isAnimationEssential",
+    "type": "boolean",
+    "label": "Animation is essential",
+    "default": false,
+    "description": "Enable this option if the image is animated and playing this animation is essential. Otherwise, the user may have requested reduced motion and needs to actively start the animation."
+  },
+  {
     "name": "alt",
     "type": "text",
     "label": "Alternative text",


### PR DESCRIPTION
The WCAG 2.1 defines a success criterion for pausing/stopping/hiding of moving, blinking, scrolling or auto-updating elements that are not _essential_ (https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide). That definition applies to animated GIFs, and the WCAG describes a suggestion for a technique to meet the success criterion (https://www.w3.org/WAI/WCAG21/Techniques/general/G152.html).

H5P.Image allows users to upload and display animated GIFs. The responsibility for not using animated GIFs at all could be delegated to the author. Here's a suggestion for direct support, really just a suggestion because some things certainly would require discussion.

The suggestion presented here will do nothing if
- an image is not a GIF,
- if a GIF image is not animated (checking function included),
- if the user did not actively request reduced motion (see https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).

Otherwise, the suggestion will
- try to compute a static GIF image as a replacement which may fail for cross-origin reasons or on iOS devices that impose limitations,
- use a static `canvas` dressed as an image for screen readers as a replacement for the animated GIF,
- add a button to toggle between the animated GIF and the static replacement in the upper right corner,
- keep the animation off by default, and
- add an option to the editor that allows authors to explicitly express that an animated image is essential.

There may be things to discuss, e.g.
- Should this be stricter and not even wait for the `prefers-reduced-motion` query to match?
- Should the animation start automatically but stop after 5 seconds (restartable using the button) as suggested in https://www.w3.org/WAI/WCAG21/Techniques/general/G152.html
- Is the `boolean` override field in the editor that allows authors to explicitly express that an animated GIF is essential in order to bypass the whole shebang necessary?
-What about images that are not added via H5P.Image but H5P core's image widget? Should this be treated similarly incl. moving some of the new functions here into H5P core and allow content types that make use of the internal widget to use them?
- ...